### PR TITLE
Hotfix: Cast potential `user_agent_views` value to integer

### DIFF
--- a/compact-custom-header.js
+++ b/compact-custom-header.js
@@ -35,7 +35,8 @@ class CompactCustomHeader extends HTMLElement {
 
     // Global variables for the main script.
     if (ua_views) {
-      window.cch_ua_views = ua_views[uai].toString().replace(/\s+/gi, '').split(',');
+      ua_views[uai] = String(ua_views[uai]);
+      window.cch_ua_views = ua_views[uai].replace(/\s+/gi, '').split(',');
     }
     window.cch_header = conf_def(header[0], header[uai], true);
     window.cch_menu = conf_def(menu[0], menu[uai], true);

--- a/compact-custom-header.js
+++ b/compact-custom-header.js
@@ -35,7 +35,7 @@ class CompactCustomHeader extends HTMLElement {
 
     // Global variables for the main script.
     if (ua_views) {
-      window.cch_ua_views = ua_views[uai].replace(/\s+/gi, '').split(',');
+      window.cch_ua_views = ua_views[uai].toString().replace(/\s+/gi, '').split(',');
     }
     window.cch_header = conf_def(header[0], header[uai], true);
     window.cch_menu = conf_def(menu[0], menu[uai], true);
@@ -48,7 +48,7 @@ class CompactCustomHeader extends HTMLElement {
     window.cch_am_pm = conf_def(clock_am_pm[0], clock_am_pm[uai], true);
     window.cch_disable = conf_def(disable[0], disable[uai], false);
     window.cch_background_image = conf_def(bg_image[0], bg_image[uai], false);
-    
+
     // Insert the main script in head, run, remove.
     const script = document.createElement('script');
     script.src = card_dir + 'compact-custom-header.lib.js?v0.2.7';


### PR DESCRIPTION
This allow for using single-digit values in the `user_agent_views` array, which are interpreted as integers. Casting the integer to a string allows for the existing value cleanup `replace(...).split(...)`.

Test:
- [x] Define a `user_agent_views` array using a single-digit view value (e.g. `- 1`)
- [x] Load the `/lovelace` path and confirm that there is no `ua_views[uai].replace` error