### PR TITLE
Use new panel selector

### DIFF
--- a/compact-custom-header.lib.js
+++ b/compact-custom-header.lib.js
@@ -3,7 +3,7 @@ if (doc_root == undefined) {
   var app_layout, card, chevron, div_view, doc_root, drawer_layout, edit_mode,
       hui_root, icon, iron_icon, love_lace, main, menu_btn, menu_icon,
       menu_iron_icon, notify_btn, notify_icon, notify_dot, notify_iron_icon,
-      options_btn, options_icon, options_iron_icon, pages, panel, proceed,
+      options_btn, options_icon, options_iron_icon, pages, proceed,
       raw_config, tabs, tabs_container, tabs_count, toolbar, voice_btn,
       voice_icon, voice_iron_icon;
 }
@@ -14,8 +14,7 @@ try {
   main = doc_root.querySelector('home-assistant-main').shadowRoot;
   drawer_layout = main.querySelector('app-drawer-layout');
   pages = drawer_layout.querySelector('partial-panel-resolver').shadowRoot;
-  panel = pages.querySelector('[id="panel"]');
-  love_lace = panel.querySelector('ha-panel-lovelace').shadowRoot;
+  love_lace = pages.querySelector('ha-panel-lovelace').shadowRoot;
   hui_root = love_lace.querySelector('hui-root').shadowRoot;
   proceed = true;
 } catch (e) {

--- a/compact-custom-header.lib.js
+++ b/compact-custom-header.lib.js
@@ -14,7 +14,7 @@ try {
   main = doc_root.querySelector('home-assistant-main').shadowRoot;
   drawer_layout = main.querySelector('app-drawer-layout');
   pages = drawer_layout.querySelector('partial-panel-resolver').shadowRoot;
-  love_lace = pages.querySelector('ha-panel-lovelace').shadowRoot;
+  love_lace = (pages.querySelector('[id="panel"]') || pages).querySelector('ha-panel-lovelace').shadowRoot;
   hui_root = love_lace.querySelector('hui-root').shadowRoot;
   proceed = true;
 } catch (e) {


### PR DESCRIPTION
The routing/selector for [the lovelace panel has changed](https://github.com/home-assistant/home-assistant-polymer/compare/20190116.0...20190121.1) in Home Assistant 0.86.0 beta.

This probably won't be backwards compatible I think. 3 options I think?
- Maybe a note should be added to the readme under "Important notes" to clarify the new version won't work on HA versions < 0.86.0?
- Hold off the update of this card and mention the changes needed for HA 0.86.0+ instead?
- Some extra code that checks the HA or frontend version to decide which selector to use?

Closes https://github.com/maykar/compact-custom-header/issues/23