### PR TITLE
Add package.yaml to support indexing on https://haindex.org

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,13 @@
+name: Compact custom header
+description: Customize the Home Assistant header!
+type: lovelace
+keywords:
+  - header
+  - compact
+  - layout
+author:
+  name: Ryan Meek
+license: Apache License, Version 2.0
+files:
+  - compact-custom-header.js
+  - compact-custom-header-editor.js

--- a/package.yaml
+++ b/package.yaml
@@ -5,6 +5,8 @@ keywords:
   - header
   - compact
   - layout
+  - views
+  - custom
 author:
   name: Ryan Meek
 license: Apache License, Version 2.0


### PR DESCRIPTION
Hey there,

I'm currently building a user generated index for Home Assistant custom components and lovelace cards: https://haindex.org
To support the index with some metadata, I've added a package description file to this repository.

It would be great if you accept the pull request and head over to https://haindex.org to get the extension indexed. Just log in with your GitHub account and submit the repository URL to be indexed.

Thanks a lot!

Best, Jens