### PR TITLE
Center #cch_clock

### DIFF
--- a/compact-custom-header.js
+++ b/compact-custom-header.js
@@ -485,13 +485,12 @@ if (!customElements.get("compact-custom-header")) {
 
         clockElement = document.createElement("p");
         clockElement.setAttribute("id", "cch_clock");
-        let clockAlign = this.cchConfig.menu == "clock" ? "left" : "right";
         let marginTop = this.cchConfig.clock_date ? "-6px" : "2px";
         clockElement.style.cssText = `
               width: ${clockWidth}px;
               margin-top: ${marginTop};
               margin-left: -8px;
-              text-align: ${clockAlign};
+              text-align: center;
             `;
         clockIronIcon.parentNode.insertBefore(clockElement, clockIronIcon);
         clockIronIcon.style.display = "none";


### PR DESCRIPTION
`#cch_clock` should always be `text-align: center` regardless of position in header.

Before:
![screenshot_20190305_230645](https://user-images.githubusercontent.com/1678118/53840872-9d1e4c00-3f9b-11e9-97bd-ef4e5895a7ab.png) ![screenshot_20190305_230522](https://user-images.githubusercontent.com/1678118/53840879-a14a6980-3f9b-11e9-9b8f-b24f41a9cfbf.png)

After:
![screenshot_20190305_230713](https://user-images.githubusercontent.com/1678118/53840884-a7d8e100-3f9b-11e9-8a21-9da13b9bb532.png) ![screenshot_20190305_230755](https://user-images.githubusercontent.com/1678118/53840891-aad3d180-3f9b-11e9-8f99-1bc2d3381c65.png)
