### PR TITLE
Swipe is now disabled on map cards

### DIFF
--- a/compact-custom-header.js
+++ b/compact-custom-header.js
@@ -1130,7 +1130,7 @@ if (!customElements.get("compact-custom-header")) {
       });
 
       function handleTouchStart(event) {
-        let ignored = ["APP-HEADER", "HA-SLIDER", "SWIPE-CARD"];
+        let ignored = ["APP-HEADER", "HA-SLIDER", "SWIPE-CARD", "HUI-MAP-CARD"];
         let path = (event.composedPath && event.composedPath()) || event.path;
         if (path) {
           for (let element of path) {


### PR DESCRIPTION
Currently, moving around a map card activates the swipe, this PR fixes this issue.