### PR TITLE
Add template for 1.1.0 breaking change

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,3 +1,4 @@
+{% if installed and version_installed < "1.1.0" %}
 ## 1.1.0 Breaking changes:
 * CCH is no longer required to be a card and only needs added as a resource.
 * Configuration happens at the root of your lovelace config in `cch:` (see links below).
@@ -6,7 +7,7 @@
 <br>
 
 I've made a [quick guide](https://maykar.github.io/compact-custom-header/1_1_0_upgrade/) for the upgrade process and [updated the docs](https://maykar.github.io/compact-custom-header/) quite a bit and they can now accept PR's, so please contribute if anything is unclear or missing.
-
+{% endif %}
 ## Features:
 
 * Compact design that removes header text.


### PR DESCRIPTION
Uses the new template options of HACS to only show the message about breaking change for 1.1.0 if the user has it installed, and the installed version is less then 1.1.0.

[Template docs](https://custom-components.github.io/hacs/developer/general/#templates)

On my setup it renders like this (with v1.2.8 installed):
![image](https://user-images.githubusercontent.com/15093472/61240814-64a92e80-a742-11e9-89f9-b2f9dc4f6206.png)
