### PR TITLE
Add backdrop_filter support

### DIFF
--- a/compact-custom-header.js
+++ b/compact-custom-header.js
@@ -31,6 +31,7 @@ const defaultConfig = {
   chevrons: false,
   redirect: true,
   background: "",
+  backdrop_filter: "",
   hide_tabs: [],
   show_tabs: [],
   default_tab: [],
@@ -356,6 +357,8 @@ function removeStyles(tabContainer, tabs, header) {
     tabContainer.style.marginRight = "";
   }
   header.style.background = null;
+  header.style.backdropFilter = null;
+  header.style.webkitBackdropFilter = null;
   view.style.minHeight = "";
   view.style.marginTop = "";
   view.style.paddingTop = "";
@@ -383,6 +386,8 @@ function styleHeader(tabContainer, tabs, header) {
       getComputedStyle(document.body).getPropertyValue("--cch-background") ||
       "var(--primary-color)";
     header.querySelector("app-toolbar").style.background = "transparent";
+    header.style.backdropFilter = cchConfig.backdrop_filter || null;
+    header.style.webkitBackdropFilter = cchConfig.backdrop_filter || null;
   }
 
   if (newSidebar && cchConfig.compact_header) {

--- a/docs/Styling-Config.md
+++ b/docs/Styling-Config.md
@@ -6,6 +6,7 @@ Style configuration can be done in yaml, raw edit mode, or from your [HA theme](
 |NAME|DESCRIPTION|
 |-|-|
 |background|Change the header's background color or image. Uses any CSS that can be used with the CSS [background-color property](https://www.w3schools.com/cssref/pr_background-color.asp), [background-image property](https://www.w3schools.com/cssref/pr_background-image.asp), or [background property](https://www.w3schools.com/cssref/css3_pr_background.asp). Examples: `background: "#000"` or even `background: url("paper.gif")`.
+|backdrop_filter|Add a backdrop-filter to the header, for example to blur the contents behind it. Uses any CSS that can be used with the CSS [backdrop-filter property](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter). Examples: `backdrop_filter: blur(10px)` or `backdrop_filter: grayscale(30%) blur(5px)`
 |all_buttons_color|Set all buttons to one color. Acts as a fallback, if set to red and a button is set to blue with button_color then all buttons will be red except for that button.
 |button_color|Set the color of a single button. See example below.
 |all_tabs_color|Set all tabs to one color. Acts as a fallback, if set to red and one tab is set to blue with tab_color then all tabs will be red except for that one tab.


### PR DESCRIPTION
With Chrome 76 supporting `backdrop-filter`, this is a good time to add this one.     
It will allow for the user to add blur and other filters to the content behind the header.

I have not added support in conditional styling yet. That could maybe be useful if it lags on a phone, though.

Note that this CSS rule is not supported by Firefox yet, but it looks like it will be added soon! [Hopefully in Firefox 70](https://bugzilla.mozilla.org/show_bug.cgi?id=1178765#c65)